### PR TITLE
Fix model for Python<->GraphQL for series image

### DIFF
--- a/lib/model/series.py
+++ b/lib/model/series.py
@@ -38,7 +38,7 @@ class Series:
         return {
             "name": self.name,
             "subtitle": self.subtitle,
-            "image3x3UrL": self.image3x2url
+            "image3x2Url": self.image3x2url
         }
 
     def one_line(self):


### PR DESCRIPTION
**Purpose**
Fix model for Python<->GraphQL for series creation as the image URL is not set. 

**Testing**
Tested using own Graph.cool instance. 